### PR TITLE
feat: list/deleteコマンド実装 - セット管理機能

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,0 +1,123 @@
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import path from 'path';
+import inquirer from 'inquirer';
+import { logger } from '../utils/logger';
+import { ClaudyError } from '../types';
+import { getClaudyDir } from '../utils/path';
+
+interface DeleteOptions {
+  verbose?: boolean;
+  force?: boolean;
+}
+
+/**
+ * セットの存在確認
+ * @param setPath - セットのパス
+ * @returns 存在する場合true
+ */
+async function existsSet(setPath: string): Promise<boolean> {
+  try {
+    const stats = await fs.stat(setPath);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * セットの削除
+ * @param setPath - セットのパス
+ */
+async function deleteSet(setPath: string): Promise<void> {
+  try {
+    await fs.remove(setPath);
+  } catch (error) {
+    throw new ClaudyError(
+      'セットの削除中にエラーが発生しました',
+      'DELETE_FAILED',
+      error
+    );
+  }
+}
+
+/**
+ * deleteコマンドの実行
+ * @param name - セット名
+ * @param options - コマンドオプション
+ */
+export async function executeDeleteCommand(
+  name: string,
+  options: DeleteOptions
+): Promise<void> {
+  try {
+    logger.setVerbose(options.verbose || false);
+    
+    // セット名のバリデーション
+    if (!name || name.trim().length === 0) {
+      throw new ClaudyError('セット名が指定されていません', 'INVALID_SET_NAME');
+    }
+    
+    logger.debug(`削除対象セット: ${name}`);
+    
+    const claudyDir = getClaudyDir();
+    const setPath = path.join(claudyDir, name);
+    logger.debug(`セットパス: ${setPath}`);
+    
+    // セットの存在確認
+    if (!await existsSet(setPath)) {
+      throw new ClaudyError(
+        `セット "${name}" が見つかりません`,
+        'SET_NOT_FOUND'
+      );
+    }
+    
+    // 削除確認
+    if (!options.force) {
+      const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `セット "${name}" を削除してもよろしいですか？`,
+          default: false,
+        },
+      ]);
+      
+      if (!confirm) {
+        logger.info('削除をキャンセルしました');
+        return;
+      }
+    }
+    
+    // セットを削除
+    logger.info('セットを削除中...');
+    await deleteSet(setPath);
+    
+    // 成功メッセージ
+    logger.success(`✓ セット "${name}" を削除しました`);
+    
+  } catch (error) {
+    if (error instanceof ClaudyError) {
+      throw error;
+    }
+    throw new ClaudyError(
+      'セットの削除中にエラーが発生しました',
+      'DELETE_ERROR',
+      error
+    );
+  }
+}
+
+/**
+ * deleteコマンドをCommanderに登録
+ * @param program - Commanderのインスタンス
+ */
+export function registerDeleteCommand(program: Command): void {
+  program
+    .command('delete <name>')
+    .description('保存済みセットを削除')
+    .option('-f, --force', '確認なしで削除')
+    .action(async (name: string, options: DeleteOptions) => {
+      await executeDeleteCommand(name, options);
+    });
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,0 +1,178 @@
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import path from 'path';
+import chalk from 'chalk';
+import { logger } from '../utils/logger';
+import { ClaudyError } from '../types';
+import { getClaudyDir } from '../utils/path';
+
+interface ListOptions {
+  verbose?: boolean;
+}
+
+interface SetInfo {
+  name: string;
+  createdAt: Date;
+  fileCount: number;
+}
+
+/**
+ * セット情報を取得
+ * @param setPath - セットのパス
+ * @returns セット情報
+ */
+async function getSetInfo(setPath: string): Promise<SetInfo | null> {
+  try {
+    const stats = await fs.stat(setPath);
+    if (!stats.isDirectory()) {
+      return null;
+    }
+
+    // ファイル数をカウント
+    const files = await countFiles(setPath);
+    
+    return {
+      name: path.basename(setPath),
+      createdAt: stats.birthtime,
+      fileCount: files,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * ディレクトリ内のファイル数をカウント
+ * @param dirPath - ディレクトリパス
+ * @returns ファイル数
+ */
+async function countFiles(dirPath: string): Promise<number> {
+  let count = 0;
+  
+  async function countRecursive(currentPath: string): Promise<void> {
+    const items = await fs.readdir(currentPath, { withFileTypes: true });
+    
+    for (const item of items) {
+      const itemPath = path.join(currentPath, item.name);
+      
+      if (item.isDirectory()) {
+        await countRecursive(itemPath);
+      } else if (item.isFile()) {
+        count++;
+      }
+    }
+  }
+  
+  await countRecursive(dirPath);
+  return count;
+}
+
+/**
+ * 日付を読みやすい形式でフォーマット
+ * @param date - 日付
+ * @returns フォーマットされた日付文字列
+ */
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  
+  return `${year}/${month}/${day} ${hours}:${minutes}`;
+}
+
+/**
+ * テーブル形式で出力
+ * @param sets - セット情報の配列
+ */
+function displayTable(sets: SetInfo[]): void {
+  if (sets.length === 0) {
+    logger.info('保存されたセットはありません');
+    return;
+  }
+
+  // ヘッダー
+  const header = chalk.bold.cyan('セット名') + '\t' + 
+                 chalk.bold.cyan('作成日時') + '\t\t' + 
+                 chalk.bold.cyan('ファイル数');
+  const separator = chalk.gray('-'.repeat(50));
+
+  console.log(header);
+  console.log(separator);
+
+  // データ行
+  for (const set of sets) {
+    const row = `${set.name}\t${formatDate(set.createdAt)}\t${set.fileCount}個`;
+    console.log(row);
+  }
+
+  console.log(separator);
+  console.log(chalk.gray(`合計: ${sets.length}個のセット`));
+}
+
+/**
+ * listコマンドの実行
+ * @param options - コマンドオプション
+ */
+export async function executeListCommand(options: ListOptions): Promise<void> {
+  try {
+    logger.setVerbose(options.verbose || false);
+    
+    const claudyDir = getClaudyDir();
+    logger.debug(`claudyディレクトリ: ${claudyDir}`);
+    
+    // claudyディレクトリの存在確認
+    if (!await fs.pathExists(claudyDir)) {
+      logger.info('保存されたセットはありません');
+      logger.info('まず claudy save <name> でセットを保存してください');
+      return;
+    }
+    
+    // セット一覧を取得
+    logger.info('保存されたセットを検索中...');
+    const items = await fs.readdir(claudyDir, { withFileTypes: true });
+    
+    const sets: SetInfo[] = [];
+    
+    for (const item of items) {
+      if (item.isDirectory() && item.name !== 'profiles' && !item.name.startsWith('.')) {
+        const setPath = path.join(claudyDir, item.name);
+        const setInfo = await getSetInfo(setPath);
+        
+        if (setInfo) {
+          sets.push(setInfo);
+        }
+      }
+    }
+    
+    // 名前順でソート
+    sets.sort((a, b) => a.name.localeCompare(b.name));
+    
+    // 表示
+    displayTable(sets);
+    
+  } catch (error) {
+    if (error instanceof ClaudyError) {
+      throw error;
+    }
+    throw new ClaudyError(
+      'セット一覧の取得中にエラーが発生しました',
+      'LIST_ERROR',
+      error
+    );
+  }
+}
+
+/**
+ * listコマンドをCommanderに登録
+ * @param program - Commanderのインスタンス
+ */
+export function registerListCommand(program: Command): void {
+  program
+    .command('list')
+    .description('保存済みセットの一覧を表示')
+    .action(async (options: ListOptions) => {
+      await executeListCommand(options);
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { initializeClaudyDir } from './utils/config';
 import { ClaudyError } from './types';
 import { registerSaveCommand } from './commands/save';
 import { registerLoadCommand } from './commands/load';
+import { registerListCommand } from './commands/list';
+import { registerDeleteCommand } from './commands/delete';
 
 async function getPackageVersion(): Promise<string> {
   try {
@@ -49,6 +51,8 @@ async function main(): Promise<void> {
 
     registerSaveCommand(program);
     registerLoadCommand(program);
+    registerListCommand(program);
+    registerDeleteCommand(program);
 
     program
       .command('help')


### PR DESCRIPTION
## 概要
Issue #4 で要求されているlist/deleteコマンドを実装しました。
保存済みセットの一覧表示と削除機能を追加し、セット管理の利便性を向上させました。

## 関連するIssue
fixes #4

## 変更内容
- `claudy list` コマンドの実装
  - 保存済みセットの一覧をテーブル形式で表示
  - セット名、作成日時、ファイル数を表示
  - セットが存在しない場合の適切なメッセージ表示
- `claudy delete <name>` コマンドの実装
  - 指定されたセットの削除機能
  - 削除前の確認プロンプト（`--force`オプションでスキップ可能）
  - 存在しないセット名に対するエラーハンドリング
- メインエントリーポイント（`src/index.ts`）への新コマンド登録

## テスト結果
- [x] ユニットテスト実行済み（既存テスト全てパス）
- [x] システムテスト実行済み（手動による動作確認）
- [x] ESLint実行済み（エラーなし）

## レビューポイント
- テーブル表示のフォーマットが適切か
- エラーメッセージがユーザーフレンドリーか
- セット削除時の確認プロンプトのUXが適切か
EOF < /dev/null