### PR TITLE
feat: saveコマンドのデフォルト動作をインタラクティブに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,26 @@ pnpm add -g claudy
 ### コマンド一覧
 
 #### `claudy save <name>`
-現在のディレクトリの設定ファイルを指定した名前で保存します。
+Claude設定ファイルを名前付きセットとして保存します。デフォルトでインタラクティブにファイルを選択できます。
 
 ```bash
-claudy save frontend        # "frontend"という名前で保存
+claudy save myproject       # インタラクティブにファイルを選択して保存（デフォルト）
+claudy save frontend -a     # 全ファイルを自動的に保存
 claudy save backend -f      # 既存のセットを強制上書き
+claudy save project-v2 -a -f # 全ファイルを自動保存し、既存セットを上書き
 ```
 
+**オプション:**
+- `-a, --all` - 全ファイルを自動的に保存（インタラクティブ選択をスキップ）
+- `-f, --force` - 既存のセットを確認なしで上書き
+
 **対象ファイル:**
-- `CLAUDE.md` - メインの設定ファイル
-- `.claude/commands/**/*.md` - カスタムコマンド定義
+- プロジェクトレベル:
+  - `CLAUDE.md` - メインの設定ファイル
+  - `.claude/commands/**/*.md` - カスタムコマンド定義
+- ユーザーレベル（デフォルトで選択可能）:
+  - `~/.claude/CLAUDE.md` - グローバル設定
+  - `~/.claude/commands/**/*.md` - グローバルコマンド
 
 #### `claudy load <name>`
 保存済みの設定セットを現在のディレクトリに展開します。
@@ -128,7 +138,7 @@ cd ~/templates/react-app
 vim CLAUDE.md
 # ... Claude AI用の詳細な指示を記載 ...
 
-# テンプレートとして保存
+# テンプレートとして保存（インタラクティブに必要なファイルのみ選択）
 claudy save react-template
 
 # 新しいプロジェクトで使用
@@ -139,8 +149,8 @@ claudy load react-template
 ### チーム内での設定共有
 
 ```bash
-# チームの標準設定を保存
-claudy save team-standard
+# チームの標準設定を保存（全ファイルを含む）
+claudy save team-standard -a
 
 # 他のメンバーも同じ設定を使用
 claudy load team-standard

--- a/docs/development/gh-instruction.md
+++ b/docs/development/gh-instruction.md
@@ -24,7 +24,7 @@ GH_PAGER= gh issue list --state open
 # 特定のIssueの詳細を確認
 GH_PAGER= gh issue view <issue番号>
 
-# Issueのコメントも含めて確認
+# 特定のIssueのコメントを確認
 GH_PAGER= gh issue view <issue番号> --comments
 ```
 

--- a/tests/integration/save.integration.test.ts
+++ b/tests/integration/save.integration.test.ts
@@ -46,8 +46,8 @@ describe('saveコマンド統合テスト', () => {
       // テスト用ファイルを作成
       await fs.writeFile(path.join(testDir, 'CLAUDE.md'), '# Test CLAUDE.md\n');
 
-      // saveコマンドを実行
-      await executeSaveCommand('test-set', {});
+      // saveコマンドを実行（--allオプションで全ファイルを自動保存）
+      await executeSaveCommand('test-set', { all: true });
 
       // ファイルが正しく保存されたか確認
       const savedFile = path.join(testClaudyDir, 'test-set', 'CLAUDE.md');
@@ -69,8 +69,8 @@ describe('saveコマンド統合テスト', () => {
         '# Test Command 2\n'
       );
 
-      // saveコマンドを実行
-      await executeSaveCommand('test-set', {});
+      // saveコマンドを実行（--allオプションで全ファイルを自動保存）
+      await executeSaveCommand('test-set', { all: true });
 
       // ファイルが正しく保存されたか確認
       const setDir = path.join(testClaudyDir, 'test-set');
@@ -93,8 +93,8 @@ describe('saveコマンド統合テスト', () => {
       // 新しいファイルを作成
       await fs.writeFile(path.join(testDir, 'CLAUDE.md'), '# New CLAUDE.md\n');
 
-      // saveコマンドを実行（--forceオプション付き）
-      await executeSaveCommand('test-set', { force: true });
+      // saveコマンドを実行（--allと--forceオプション付き）
+      await executeSaveCommand('test-set', { all: true, force: true });
 
       // 新しいファイルで上書きされたか確認
       expect(await fs.pathExists(path.join(setDir, 'old.md'))).toBe(true); // 古いファイルも残る
@@ -107,7 +107,7 @@ describe('saveコマンド統合テスト', () => {
     it('対象ファイルが存在しない場合エラーになる', async () => {
       // 何もファイルを作成しない
 
-      await expect(executeSaveCommand('test-set', {})).rejects.toThrow(
+      await expect(executeSaveCommand('test-set', { all: true })).rejects.toThrow(
         '保存対象のファイルが見つかりません。'
       );
     });
@@ -119,7 +119,7 @@ describe('saveコマンド統合テスト', () => {
       await fs.ensureDir(path.join(testDir, 'other'));
       await fs.writeFile(path.join(testDir, 'other', 'test.md'), '# Other\n');
 
-      await expect(executeSaveCommand('test-set', {})).rejects.toThrow(
+      await expect(executeSaveCommand('test-set', { all: true })).rejects.toThrow(
         '保存対象のファイルが見つかりません。'
       );
     });


### PR DESCRIPTION
## 概要
saveコマンドのデフォルト動作をインタラクティブなファイル選択モードに変更し、ユーザーが意図しないファイルの保存を防ぎ、より安全で柔軟な操作を可能にしました。

## 関連するIssue
fixes #11

## 変更内容
- `claudy save`のデフォルト動作をインタラクティブモードに変更
- `--all` (`-a`) フラグを追加し、従来の全ファイル自動保存動作を維持
- `-i/--interactive` オプションは廃止予定として警告を表示
- 保存結果のサマリー表示を改善（プロジェクト/ユーザーレベルのファイル数内訳を表示）
- ユニットテストと統合テストを更新
- READMEドキュメントにデフォルト動作の変更を反映

## テスト結果
- [x] ユニットテスト実行済み（12テストすべてパス）
- [x] 統合テスト実行済み（5テストすべてパス）
- [x] 全テスト実行済み（59テストすべてパス）

## レビューポイント
- デフォルト動作の変更がユーザー体験に与える影響
- `-i`オプションの廃止予定警告の文言
- 保存結果サマリーの表示形式

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF < /dev/null