### PR TITLE
fix: ESモジュールのインポートパスに.js拡張子を追加

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,12 +1,13 @@
 import { Command } from 'commander';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import path from 'path';
 import inquirer from 'inquirer';
-import { logger } from '../utils/logger';
-import { ClaudyError } from '../types';
-import { getProjectConfigDir } from '../utils/path';
-import { ErrorCodes, ErrorMessages, wrapError } from '../types/errors';
-import { handleFileOperation, handleError } from '../utils/errorHandler';
+import { logger } from '../utils/logger.js';
+import { ClaudyError } from '../types/index.js';
+import { getProjectConfigDir } from '../utils/path.js';
+import { ErrorCodes, ErrorMessages, wrapError } from '../types/errors.js';
+import { handleFileOperation, handleError } from '../utils/errorHandler.js';
 
 interface DeleteOptions {
   verbose?: boolean;

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,12 +1,13 @@
 import { Command } from 'commander';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import path from 'path';
 import chalk from 'chalk';
-import { logger } from '../utils/logger';
-import { ClaudyError } from '../types';
-import { getProjectConfigDir } from '../utils/path';
-import { ErrorCodes, wrapError } from '../types/errors';
-import { handleFileOperation, handleError } from '../utils/errorHandler';
+import { logger } from '../utils/logger.js';
+import { ClaudyError } from '../types/index.js';
+import { getProjectConfigDir } from '../utils/path.js';
+import { ErrorCodes, wrapError } from '../types/errors.js';
+import { handleFileOperation, handleError } from '../utils/errorHandler.js';
 
 interface ListOptions {
   verbose?: boolean;

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,13 +1,14 @@
 import { Command } from 'commander';
 import path from 'path';
-import { stat, copy, rename, remove, ensureDir } from 'fs-extra';
+import fsExtra from 'fs-extra';
+const { stat, copy, rename, remove, ensureDir } = fsExtra;
 import inquirer from 'inquirer';
-import { logger } from '../utils/logger';
-import { getProjectConfigDir } from '../utils/path';
-import { ClaudyError } from '../types';
+import { logger } from '../utils/logger.js';
+import { getProjectConfigDir } from '../utils/path.js';
+import { ClaudyError } from '../types/index.js';
 import { glob } from 'glob';
-import { ErrorCodes, ErrorMessages, wrapError } from '../types/errors';
-import { handleFileOperation, withRetry, handleError } from '../utils/errorHandler';
+import { ErrorCodes, ErrorMessages, wrapError } from '../types/errors.js';
+import { handleFileOperation, withRetry, handleError } from '../utils/errorHandler.js';
 
 interface LoadOptions {
   verbose?: boolean;

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,9 +1,9 @@
 import { Command } from 'commander';
-import { logger } from '../utils/logger';
-import { ClaudyError } from '../types';
-import { ErrorCodes, wrapError } from '../types/errors';
-import { handleError } from '../utils/errorHandler';
-import { checkAndMigrateLegacyConfig } from '../utils/config';
+import { logger } from '../utils/logger.js';
+import { ClaudyError } from '../types/index.js';
+import { ErrorCodes, wrapError } from '../types/errors.js';
+import { handleError } from '../utils/errorHandler.js';
+import { checkAndMigrateLegacyConfig } from '../utils/config.js';
 
 interface MigrateOptions {
   verbose?: boolean;

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -1,14 +1,15 @@
 import { Command } from 'commander';
 import path from 'path';
 import { glob } from 'glob';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import inquirer from 'inquirer';
-import { logger } from '../utils/logger';
-import { ClaudyError } from '../types';
-import { ErrorCodes, ErrorMessages, wrapError } from '../types/errors';
-import { handleFileOperation, withRetry, handleError } from '../utils/errorHandler';
-import { getProjectConfigDir } from '../utils/path';
-import { performFileSelection, FileSelectionResult } from '../utils/file-selector';
+import { logger } from '../utils/logger.js';
+import { ClaudyError } from '../types/index.js';
+import { ErrorCodes, ErrorMessages, wrapError } from '../types/errors.js';
+import { handleFileOperation, withRetry, handleError } from '../utils/errorHandler.js';
+import { getProjectConfigDir } from '../utils/path.js';
+import { performFileSelection, FileSelectionResult } from '../utils/file-selector.js';
 
 interface SaveOptions {
   verbose?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,20 @@
 import { Command } from 'commander';
 import { readFile } from 'fs/promises';
 import path from 'path';
-import { logger } from './utils/logger';
-import { initializeClaudyDir } from './utils/config';
-import { ClaudyError } from './types';
-import { ErrorCodes, formatErrorMessage } from './types/errors';
-import { handleError as handleClaudyError } from './utils/errorHandler';
-import { registerSaveCommand } from './commands/save';
-import { registerLoadCommand } from './commands/load';
-import { registerListCommand } from './commands/list';
-import { registerDeleteCommand } from './commands/delete';
-import { registerMigrateCommand } from './commands/migrate';
+import { fileURLToPath } from 'url';
+import { logger } from './utils/logger.js';
+import { initializeClaudyDir } from './utils/config.js';
+import { ClaudyError } from './types/index.js';
+import { ErrorCodes, formatErrorMessage } from './types/errors.js';
+import { handleError as handleClaudyError } from './utils/errorHandler.js';
+import { registerSaveCommand } from './commands/save.js';
+import { registerLoadCommand } from './commands/load.js';
+import { registerListCommand } from './commands/list.js';
+import { registerDeleteCommand } from './commands/delete.js';
+import { registerMigrateCommand } from './commands/migrate.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 async function getPackageVersion(): Promise<string> {
   try {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,4 +1,4 @@
-import { ClaudyError } from './index';
+import { ClaudyError } from './index.js';
 
 // エラーコードのカテゴリー別定義
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,4 +1,4 @@
-import { ClaudyConfig, ClaudyError } from '../types';
+import { ClaudyConfig, ClaudyError } from '../types/index.js';
 import { 
   getConfigPath, 
   getClaudyDir, 
@@ -6,9 +6,9 @@ import {
   getUserConfigDir,
   getProjectsDir,
   getLegacyClaudyDir
-} from './path';
-import { readJson, writeJson, fileExists, ensureDir, copyFileOrDir } from './file';
-import { logger } from './logger';
+} from './path.js';
+import { readJson, writeJson, fileExists, ensureDir, copyFileOrDir } from './file.js';
+import { logger } from './logger.js';
 import path from 'path';
 
 const DEFAULT_CONFIG: ClaudyConfig = {

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,6 +1,6 @@
-import { logger } from './logger';
-import { ClaudyError } from '../types';
-import { ErrorCode, formatErrorMessage, wrapError } from '../types/errors';
+import { logger } from './logger.js';
+import { ClaudyError } from '../types/index.js';
+import { ErrorCode, formatErrorMessage, wrapError } from '../types/errors.js';
 
 // リトライ可能なエラーコード
 const RETRYABLE_ERROR_CODES: ErrorCode[] = [

--- a/src/utils/file-selector.ts
+++ b/src/utils/file-selector.ts
@@ -1,12 +1,13 @@
 import path from 'path';
 import os from 'os';
 import { glob } from 'glob';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import inquirer from 'inquirer';
-import { logger } from './logger';
-import { ClaudyError } from '../types';
-import { ErrorCodes, wrapError } from '../types/errors';
-import { collectReferences, ReferencedFile } from './reference-parser';
+import { logger } from './logger.js';
+import { ClaudyError } from '../types/index.js';
+import { ErrorCodes, wrapError } from '../types/errors.js';
+import { collectReferences, ReferencedFile } from './reference-parser.js';
 
 export interface FileSelectionResult {
   files: string[];

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,7 +1,8 @@
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import path from 'path';
-import { ClaudyError } from '../types';
-import { logger } from './logger';
+import { ClaudyError } from '../types/index.js';
+import { logger } from './logger.js';
 
 export async function ensureDir(dirPath: string): Promise<void> {
   try {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
-import { ClaudyError } from '../types';
+import { ClaudyError } from '../types/index.js';
 
 export function getHomeDir(): string {
   const homeDir = os.homedir();

--- a/src/utils/reference-parser.ts
+++ b/src/utils/reference-parser.ts
@@ -1,6 +1,7 @@
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import path from 'path';
-import { logger } from './logger';
+import { logger } from './logger.js';
 
 /**
  * 参照ファイル情報

--- a/tests/commands/delete.test.ts
+++ b/tests/commands/delete.test.ts
@@ -5,19 +5,25 @@ import { ErrorCodes } from '../../src/types/errors';
 
 // モックの設定
 vi.mock('../../src/utils/logger');
-vi.mock('fs-extra');
+vi.mock('fs-extra', () => ({
+  default: {
+    stat: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
 vi.mock('../../src/utils/path');
 vi.mock('inquirer');
 
 // モジュールのインポート（モック後に行う）
 import { logger } from '../../src/utils/logger';
 import * as pathUtils from '../../src/utils/path';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import inquirer from 'inquirer';
 
 const mockLogger = vi.mocked(logger);
 const mockPathUtils = vi.mocked(pathUtils);
-const mockFs = vi.mocked(fs);
+const mockFs = vi.mocked(fsExtra);
 const mockInquirer = vi.mocked(inquirer);
 
 describe('deleteコマンド', () => {

--- a/tests/commands/list.test.ts
+++ b/tests/commands/list.test.ts
@@ -3,13 +3,20 @@ import { executeListCommand } from '../../src/commands/list';
 
 // モックの設定
 vi.mock('../../src/utils/logger');
-vi.mock('fs-extra');
+vi.mock('fs-extra', () => ({
+  default: {
+    access: vi.fn(),
+    readdir: vi.fn(),
+    stat: vi.fn(),
+  },
+}));
 vi.mock('../../src/utils/path');
 
 // モジュールのインポート（モック後に行う）
 import { logger } from '../../src/utils/logger';
 import * as pathUtils from '../../src/utils/path';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 
 const mockLogger = vi.mocked(logger);
 const mockPathUtils = vi.mocked(pathUtils);

--- a/tests/commands/load.test.ts
+++ b/tests/commands/load.test.ts
@@ -11,6 +11,13 @@ vi.mock('glob');
 
 // fs-extraの個別関数をモック
 vi.mock('fs-extra', () => ({
+  default: {
+    stat: vi.fn(),
+    copy: vi.fn(),
+    ensureDir: vi.fn(),
+    rename: vi.fn(),
+    remove: vi.fn(),
+  },
   stat: vi.fn(),
   copy: vi.fn(),
   ensureDir: vi.fn(),
@@ -21,7 +28,8 @@ vi.mock('fs-extra', () => ({
 // モジュールのインポート（モック後に行う）
 import { logger } from '../../src/utils/logger';
 import * as pathUtils from '../../src/utils/path';
-import { stat, copy, ensureDir, rename, remove } from 'fs-extra';
+import fsExtra from 'fs-extra';
+const { stat, copy, ensureDir, rename, remove } = fsExtra;
 import inquirer from 'inquirer';
 import { glob } from 'glob';
 

--- a/tests/commands/save.test.ts
+++ b/tests/commands/save.test.ts
@@ -5,7 +5,15 @@ import { ErrorCodes } from '../../src/types/errors';
 
 // モックの設定
 vi.mock('../../src/utils/logger');
-vi.mock('fs-extra');
+vi.mock('fs-extra', () => ({
+  default: {
+    access: vi.fn(),
+    ensureDir: vi.fn(),
+    copy: vi.fn(),
+    stat: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
 vi.mock('../../src/utils/path');
 vi.mock('inquirer');
 vi.mock('glob');
@@ -14,14 +22,15 @@ vi.mock('../../src/utils/file-selector');
 // モジュールのインポート（モック後に行う）
 import { logger } from '../../src/utils/logger';
 import * as pathUtils from '../../src/utils/path';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import inquirer from 'inquirer';
 import { glob } from 'glob';
 import { performFileSelection } from '../../src/utils/file-selector';
 
 const mockLogger = vi.mocked(logger);
 const mockPathUtils = vi.mocked(pathUtils);
-const mockFs = vi.mocked(fs);
+const mockFs = vi.mocked(fsExtra);
 const mockInquirer = vi.mocked(inquirer);
 const mockGlob = vi.mocked(glob);
 const mockPerformFileSelection = vi.mocked(performFileSelection);

--- a/tests/utils/file-selector.test.ts
+++ b/tests/utils/file-selector.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import path from 'path';
 import os from 'os';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import inquirer from 'inquirer';
 import { glob } from 'glob';
 import {
@@ -15,7 +16,11 @@ import {
 
 // Mocks
 vi.mock('glob');
-vi.mock('fs-extra');
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+  },
+}));
 vi.mock('inquirer');
 vi.mock('../../src/utils/logger');
 vi.mock('../../src/utils/reference-parser', () => ({
@@ -23,7 +28,7 @@ vi.mock('../../src/utils/reference-parser', () => ({
 }));
 
 const mockGlob = vi.mocked(glob);
-const mockFs = vi.mocked(fs) as any;
+const mockFs = vi.mocked(fsExtra) as any;
 const mockInquirer = vi.mocked(inquirer);
 
 describe('file-selector', () => {

--- a/tests/utils/reference-parser.test.ts
+++ b/tests/utils/reference-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import fs from 'fs-extra';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
 import path from 'path';
 import {
   extractFileReferences,
@@ -8,10 +9,15 @@ import {
   ReferencedFile
 } from '../../src/utils/reference-parser';
 
-vi.mock('fs-extra');
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    readFile: vi.fn(),
+  },
+}));
 vi.mock('../../src/utils/logger');
 
-const mockFs = fs as any;
+const mockFs = fsExtra as any;
 
 describe('reference-parser', () => {
   beforeEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## 概要
ESモジュール形式でのインポートエラーを修正しました。TypeScriptのソースファイルで相対インポートに.js拡張子が必要でしたが、これが不足していたため実行時エラーが発生していました。

## 関連するIssue
該当なし（エラー修正）

## 変更内容
- すべてのTypeScriptファイルで相対インポートに`.js`拡張子を追加
- `import.meta.url`を使用してESモジュール対応の`__dirname`を定義
- `tsconfig.json`の`moduleResolution`を`node`に変更
- fs-extraのCommonJSモジュール問題を解決（デフォルトインポートを使用）

## テスト結果
- [x] ユニットテスト実行済み（85個のテストすべて成功）
- [x] ビルド成功
- [x] CLIコマンドの動作確認済み

## エラーの詳細
修正前のエラー:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/douhashi/workspace/github.com/douhashi/claudy/dist/utils/logger' imported from /home/douhashi/workspace/github.com/douhashi/claudy/dist/index.js
```

## レビューポイント
- ESモジュール形式への移行が適切に行われているか
- fs-extraのインポート方法の変更が問題ないか

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF < /dev/null