### PR TITLE
fix: i18n翻訳キーが実際のメッセージの代わりに表示される問題

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -31,7 +31,16 @@
     "searchingFiles": "Searching for Claude configuration files...",
     "patternError": "Error searching pattern \"{{pattern}}\": {{error}}",
     "projectLevelDebug": "Project level: {{mainCount}} main file(s), {{refCount}} referenced file(s) found",
-    "userLevelDebug": "User level: {{mainCount}} main file(s), {{refCount}} referenced file(s) found"
+    "userLevelDebug": "User level: {{mainCount}} main file(s), {{refCount}} referenced file(s) found",
+    "howToSelect": "Select file selection method:",
+    "bothFiles": "Both files (Project level + User level)",
+    "projectOnly": "Project level files only",
+    "userOnly": "User level files only",
+    "customSelect": "Custom selection (select files individually)",
+    "selectAllProject": "Select all project level files",
+    "selectAllUser": "Select all user level files",
+    "projectLevelSeparator": "--- Project level ---",
+    "errorSelecting": "Error occurred while selecting files"
   },
   "validation": {
     "invalidName": "Name can only contain alphanumeric characters, hyphens, and underscores"
@@ -53,6 +62,33 @@
     "legacyDetected": "Legacy configuration directory detected. Starting migration to new format...",
     "migrationError": "Error occurred during configuration migration:",
     "configLoadError": "Failed to load configuration",
-    "configSaveError": "Failed to save configuration"
+    "configSaveError": "Failed to save configuration",
+    "initialized": "claudy configuration initialized (XDG Base Directory compliant)"
+  },
+  "path": {
+    "homeNotFound": "Home directory not found",
+    "setNameRequired": "Set name is required",
+    "invalidSetName": "Invalid set name",
+    "emptyPartInName": "Set name contains empty parts",
+    "invalidCharacters": "Set name contains invalid characters",
+    "reservedWord": "\"{{part}}\" is a reserved word and cannot be used",
+    "cannotStartWithDot": "Set name cannot start with a dot"
+  },
+  "debug": {
+    "directorySecured": "Directory created: {{dirPath}}",
+    "fileRead": "File read: {{filePath}}",
+    "fileWritten": "File written: {{filePath}}",
+    "fileCopied": "File copied: {{src}} → {{dest}}",
+    "fileDeleted": "File deleted: {{filePath}}",
+    "directoryCopied": "Directory copied: {{src}} → {{dest}}",
+    "errorSearchingFiles": "Error searching user-level command files: {{error}}",
+    "setAccessFailed": "Cannot access set: {{setPath}} ({{code}})",
+    "accessDenied": "Access denied: {{path}}",
+    "extractedReferences": "Extracted references: {{references}}",
+    "referencePathResolved": "Reference path resolved: {{referencePath}} -> {{relativePath}}",
+    "referencePathFailed": "Failed to resolve reference path: {{referencePath}} - {{error}}",
+    "depthLimitReached": "Depth limit reached: {{filePath}} (depth={{depth}})",
+    "alreadyProcessed": "File already processed: {{filePath}}",
+    "fileReadError": "File read error: {{filePath}} - {{error}}"
   }
 }

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -13,20 +13,23 @@
     "dirNotFound": "Directory not found.",
     "homeDirNotFound": "Home directory not found.",
     "noFilesFound": "No files to save were found.",
-    "noConfigFiles": "Configuration files not found."
+    "noConfigFiles": "Configuration files not found.",
+    "setNotFoundDetail": "Set \"{{setName}}\" not found. Use 'claudy list' to check available sets."
   },
   "permission": {
     "denied": "Access denied.",
     "readDenied": "No read permission for the file.",
     "writeDenied": "No write permission for the file.",
-    "executeDenied": "No execute permission for the file."
+    "executeDenied": "No execute permission for the file.",
+    "fileAccessDenied": "Access denied to file or directory{{path}}"
   },
   "filesystem": {
     "diskFull": "Insufficient disk space.",
     "fileLocked": "File is locked by another process.",
     "pathTooLong": "Path is too long.",
     "invalidFileName": "Invalid file name.",
-    "symlinkLoop": "Symbolic link loop detected."
+    "symlinkLoop": "Symbolic link loop detected.",
+    "diskFullWithPath": "Insufficient disk space{{path}}"
   },
   "operation": {
     "saveError": "Failed to save the set.",
@@ -37,7 +40,8 @@
     "backupFailed": "Failed to create backup.",
     "expandFailed": "Failed to expand files.",
     "rollbackFailed": "Failed to rollback.",
-    "migrationError": "Failed to migrate configuration."
+    "migrationError": "Failed to migrate configuration.",
+    "retryAfterError": "An error occurred. Retrying in {{waitTime}}ms... ({{attempt}}/{{maxAttempts}})"
   },
   "file": {
     "readError": "Failed to read file.",

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -79,7 +79,7 @@ async function getSetInfo(setPath: string, basePath: string): Promise<SetInfo | 
     // アクセスエラーの場合はnullを返す
     const systemError = error as NodeJS.ErrnoException;
     if (systemError.code === 'EACCES' || systemError.code === 'ENOENT') {
-      logger.debug(`セットへのアクセス不可: ${setPath} (${systemError.code})`);
+      logger.debug(t('common:debug.setAccessFailed', { setPath, code: systemError.code }));
       return null;
     }
     // その他のエラーは再スロー
@@ -117,7 +117,7 @@ async function countFiles(dirPath: string): Promise<number> {
       // アクセスエラーの場合はスキップ
       const systemError = error as NodeJS.ErrnoException;
       if (systemError.code === 'EACCES') {
-        logger.debug(`アクセス拒否: ${currentPath}`);
+        logger.debug(t('common:debug.accessDenied', { path: currentPath }));
         return;
       }
       throw error;
@@ -251,7 +251,7 @@ async function findSetsRecursive(dirPath: string, basePath: string, depth: numbe
   } catch (error) {
     const systemError = error as NodeJS.ErrnoException;
     if (systemError.code === 'EACCES') {
-      logger.debug(`アクセス拒否: ${dirPath}`);
+      logger.debug(t('common:debug.accessDenied', { path: dirPath }));
     } else {
       throw error;
     }

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -251,7 +251,7 @@ export async function executeSaveCommand(
     if (error instanceof ClaudyError) {
       throw error;
     }
-    throw wrapError(error, ErrorCodes.SAVE_ERROR, 'セットの保存中にエラーが発生しました', { setName: name });
+    throw wrapError(error, ErrorCodes.SAVE_ERROR, t('errors:operation.saveError'), { setName: name });
   }
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -42,7 +42,7 @@ export async function initializeClaudyDir(): Promise<void> {
 
   if (!configExists) {
     await writeJson(configPath, DEFAULT_CONFIG);
-    logger.success('claudy configuration initialized (XDG Base Directory compliant)');
+    logger.success(t('common:config.initialized'));
   }
 }
 

--- a/src/utils/file-selector.ts
+++ b/src/utils/file-selector.ts
@@ -123,7 +123,7 @@ export async function findUserClaudeFiles(
     });
     mainFiles.push(...commandFiles.map(f => path.join('.claude', f)));
   } catch (error) {
-    logger.debug(`Error searching user-level command files: ${error}`);
+    logger.debug(t('common:debug.errorSearchingFiles', { error }));
   }
   
   // 参照ファイルを収集
@@ -208,27 +208,27 @@ async function selectGroup(hasProjectFiles: boolean, hasUserFiles: boolean): Pro
   
   if (hasProjectFiles && hasUserFiles) {
     choices.push(
-      { name: '両方のファイル（プロジェクトレベル + ユーザーレベル）', value: 'both' },
-      { name: 'プロジェクトレベルのファイルのみ', value: 'project' },
-      { name: 'ユーザーレベルのファイルのみ', value: 'user' },
-      { name: 'カスタム選択（個別にファイルを選択）', value: 'custom' }
+      { name: t('common:fileSelection.bothFiles'), value: 'both' },
+      { name: t('common:fileSelection.projectOnly'), value: 'project' },
+      { name: t('common:fileSelection.userOnly'), value: 'user' },
+      { name: t('common:fileSelection.customSelect'), value: 'custom' }
     );
   } else if (hasProjectFiles) {
     choices.push(
-      { name: 'プロジェクトレベルのファイルをすべて選択', value: 'project' },
-      { name: 'カスタム選択（個別にファイルを選択）', value: 'custom' }
+      { name: t('common:fileSelection.selectAllProject'), value: 'project' },
+      { name: t('common:fileSelection.customSelect'), value: 'custom' }
     );
   } else if (hasUserFiles) {
     choices.push(
-      { name: 'ユーザーレベルのファイルをすべて選択', value: 'user' },
-      { name: 'カスタム選択（個別にファイルを選択）', value: 'custom' }
+      { name: t('common:fileSelection.selectAllUser'), value: 'user' },
+      { name: t('common:fileSelection.customSelect'), value: 'custom' }
     );
   }
   
   const { selection } = await inquirer.prompt<{ selection: GroupSelectionOption }>({
     type: 'list',
     name: 'selection',
-    message: 'ファイルの選択方法を選んでください:',
+    message: t('common:fileSelection.howToSelect'),
     choices,
     default: hasProjectFiles && hasUserFiles ? 'both' : (hasProjectFiles ? 'project' : 'user'),
   });
@@ -469,7 +469,7 @@ export async function selectFilesInteractively(
   
   // プロジェクトレベルのメインファイル
   if (projectFiles.mainFiles.length > 0) {
-    choices.push(new inquirer.Separator('--- プロジェクトレベル ---'))
+    choices.push(new inquirer.Separator(t('common:fileSelection.projectLevelSeparator')))
     
     for (const file of projectFiles.mainFiles) {
       choices.push({
@@ -594,7 +594,7 @@ export async function selectFilesInteractively(
   }
   
   const totalFiles = selectedProjectFiles.length + selectedUserFiles.length;
-  logger.info(`✓ ${totalFiles}個のファイルを選択しました`);
+  logger.info(t('common:fileSelection.filesSelected', { count: totalFiles }));
   
   return results;
 }
@@ -628,6 +628,6 @@ export async function performFileSelection(): Promise<FileSelectionResult[]> {
     if (error instanceof ClaudyError) {
       throw error;
     }
-    throw wrapError(error, ErrorCodes.FILE_SELECTION_ERROR, 'ファイル選択中にエラーが発生しました');
+    throw wrapError(error, ErrorCodes.FILE_SELECTION_ERROR, t('common:fileSelection.errorSelecting'));
   }
 }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -3,6 +3,7 @@ const fs = fsExtra;
 import path from 'path';
 import { ClaudyError } from '../types/index.js';
 import { logger } from './logger.js';
+import { t } from './i18n.js';
 
 /**
  * ディレクトリを確保（存在しない場合は作成）
@@ -12,7 +13,7 @@ import { logger } from './logger.js';
 export async function ensureDir(dirPath: string): Promise<void> {
   try {
     await fs.ensureDir(dirPath);
-    logger.debug(`ディレクトリを確保しました: ${dirPath}`);
+    logger.debug(t('common:debug.directorySecured', { dirPath }));
   } catch (error) {
     throw new ClaudyError(
       `ディレクトリの作成に失敗しました: ${dirPath}`,
@@ -45,7 +46,7 @@ export async function fileExists(filePath: string): Promise<boolean> {
 export async function readFile(filePath: string): Promise<string> {
   try {
     const content = await fs.readFile(filePath, 'utf-8');
-    logger.debug(`ファイルを読み込みました: ${filePath}`);
+    logger.debug(t('common:debug.fileRead', { filePath }));
     return content;
   } catch (error) {
     throw new ClaudyError(
@@ -66,7 +67,7 @@ export async function writeFile(filePath: string, content: string): Promise<void
   try {
     await fs.ensureDir(path.dirname(filePath));
     await fs.writeFile(filePath, content, 'utf-8');
-    logger.debug(`ファイルを書き込みました: ${filePath}`);
+    logger.debug(t('common:debug.fileWritten', { filePath }));
   } catch (error) {
     throw new ClaudyError(
       `ファイルの書き込みに失敗しました: ${filePath}`,
@@ -86,7 +87,7 @@ export async function copyFile(src: string, dest: string): Promise<void> {
   try {
     await fs.ensureDir(path.dirname(dest));
     await fs.copy(src, dest);
-    logger.debug(`ファイルをコピーしました: ${src} → ${dest}`);
+    logger.debug(t('common:debug.fileCopied', { src, dest }));
   } catch (error) {
     throw new ClaudyError(
       `ファイルのコピーに失敗しました: ${src} → ${dest}`,
@@ -104,7 +105,7 @@ export async function copyFile(src: string, dest: string): Promise<void> {
 export async function removeFile(filePath: string): Promise<void> {
   try {
     await fs.remove(filePath);
-    logger.debug(`ファイルを削除しました: ${filePath}`);
+    logger.debug(t('common:debug.fileDeleted', { filePath }));
   } catch (error) {
     throw new ClaudyError(
       `ファイルの削除に失敗しました: ${filePath}`,
@@ -168,7 +169,7 @@ export async function copyFileOrDir(src: string, dest: string): Promise<void> {
   try {
     await fs.ensureDir(path.dirname(dest));
     await fs.copy(src, dest, { overwrite: false });
-    logger.debug(`ディレクトリをコピーしました: ${src} → ${dest}`);
+    logger.debug(t('common:debug.directoryCopied', { src, dest }));
   } catch (error) {
     throw new ClaudyError(
       `ディレクトリのコピーに失敗しました: ${src} → ${dest}`,

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
 import { ClaudyError } from '../types/index.js';
+import { t } from './i18n.js';
 
 /**
  * ホームディレクトリを取得
@@ -11,7 +12,7 @@ import { ClaudyError } from '../types/index.js';
 export function getHomeDir(): string {
   const homeDir = os.homedir();
   if (!homeDir) {
-    throw new ClaudyError('ホームディレクトリが見つかりません', 'HOME_DIR_NOT_FOUND');
+    throw new ClaudyError(t('common:path.homeNotFound'), 'HOME_DIR_NOT_FOUND');
   }
   return homeDir;
 }
@@ -163,13 +164,13 @@ export function getSetDir(setName: string): string {
  */
 export function validateSetName(setName: string): void {
   if (!setName || setName.trim() === '') {
-    throw new ClaudyError('セット名を指定してください', 'INVALID_SET_NAME');
+    throw new ClaudyError(t('common:path.setNameRequired'), 'INVALID_SET_NAME');
   }
 
   // パストラバーサル攻撃の防止
   const normalizedName = path.normalize(setName);
   if (normalizedName.includes('..') || path.isAbsolute(normalizedName)) {
-    throw new ClaudyError('無効なセット名です', 'INVALID_SET_NAME', { setName });
+    throw new ClaudyError(t('common:path.invalidSetName'), 'INVALID_SET_NAME', { setName });
   }
 
   // OSごとの予約語と特殊文字のチェック
@@ -180,21 +181,21 @@ export function validateSetName(setName: string): void {
   const parts = setName.split('/');
   for (const part of parts) {
     if (!part || part.trim() === '') {
-      throw new ClaudyError('セット名に空のパートが含まれています', 'INVALID_SET_NAME', { setName });
+      throw new ClaudyError(t('common:path.emptyPartInName'), 'INVALID_SET_NAME', { setName });
     }
     
     if (invalidChars.test(part)) {
-      throw new ClaudyError('セット名に使用できない文字が含まれています', 'INVALID_SET_NAME', { setName });
+      throw new ClaudyError(t('common:path.invalidCharacters'), 'INVALID_SET_NAME', { setName });
     }
     
     const upperPart = part.toUpperCase();
     if (invalidNames.includes(upperPart)) {
-      throw new ClaudyError(`"${part}"は予約語のため使用できません`, 'INVALID_SET_NAME', { setName });
+      throw new ClaudyError(t('common:path.reservedWord', { part }), 'INVALID_SET_NAME', { setName });
     }
     
     // ドットで始まる名前の禁止
     if (part.startsWith('.')) {
-      throw new ClaudyError('セット名はドットで始めることはできません', 'INVALID_SET_NAME', { setName });
+      throw new ClaudyError(t('common:path.cannotStartWithDot'), 'INVALID_SET_NAME', { setName });
     }
   }
 }

--- a/src/utils/reference-parser.ts
+++ b/src/utils/reference-parser.ts
@@ -2,6 +2,7 @@ import fsExtra from 'fs-extra';
 const fs = fsExtra;
 import path from 'path';
 import { logger } from './logger.js';
+import { t } from './i18n.js';
 
 /**
  * 参照ファイル情報
@@ -30,7 +31,7 @@ export function extractFileReferences(content: string): string[] {
     }
   }
   
-  logger.debug(`抽出された参照: ${references.join(', ')}`);
+  logger.debug(t('common:debug.extractedReferences', { references: references.join(', ') }));
   return references;
 }
 
@@ -64,11 +65,11 @@ export async function resolveReferencePath(
     if (exists) {
       // baseDirからの相対パスに変換して返す
       const relativePath = path.relative(baseDir, resolvedPath);
-      logger.debug(`参照パス解決: ${referencePath} -> ${relativePath}`);
+      logger.debug(t('common:debug.referencePathResolved', { referencePath, relativePath }));
       return relativePath;
     }
   } catch (error) {
-    logger.debug(`参照パスの解決に失敗: ${referencePath} - ${error}`);
+    logger.debug(t('common:debug.referencePathFailed', { referencePath, error }));
   }
   
   return null;
@@ -92,14 +93,14 @@ export async function collectReferences(
 ): Promise<ReferencedFile[]> {
   // 深さ制限チェック
   if (depth >= maxDepth) {
-    logger.debug(`深さ制限に達しました: ${filePath} (depth=${depth})`);
+    logger.debug(t('common:debug.depthLimitReached', { filePath, depth }));
     return [];
   }
   
   // 循環参照チェック
   const normalizedPath = path.normalize(filePath);
   if (processedFiles.has(normalizedPath)) {
-    logger.debug(`既に処理済みのファイル: ${filePath}`);
+    logger.debug(t('common:debug.alreadyProcessed', { filePath }));
     return [];
   }
   
@@ -161,7 +162,7 @@ export async function collectReferences(
       }
     }
   } catch (error) {
-    logger.debug(`ファイル読み込みエラー: ${filePath} - ${error}`);
+    logger.debug(t('common:debug.fileReadError', { filePath, error }));
   }
   
   return referencedFiles;

--- a/tests/integration/cli-output.test.ts
+++ b/tests/integration/cli-output.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import path from 'path';
+import fsExtra from 'fs-extra';
+const fs = fsExtra;
+import os from 'os';
+
+describe('CLI output does not contain translation keys', () => {
+  let tempDir: string;
+  let originalCwd: string;
+  const setName = 'test-cli-output';
+
+  beforeEach(async () => {
+    // Create a temporary directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claudy-test-'));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+
+    // Create test files
+    await fs.writeFile('CLAUDE.md', '# Test CLAUDE.md file');
+    await fs.ensureDir('.claude/commands');
+    await fs.writeFile('.claude/commands/test.md', '# Test command');
+  });
+
+  afterEach(async () => {
+    // Restore original directory
+    process.chdir(originalCwd);
+    
+    // Clean up temp directory
+    await fs.remove(tempDir);
+
+    // Clean up saved set if it exists
+    const homeDir = os.homedir();
+    const setPath = path.join(homeDir, '.config', 'claudy', 'sets', setName);
+    if (await fs.pathExists(setPath)) {
+      await fs.remove(setPath);
+    }
+  });
+
+  const runCommand = (cmd: string): string => {
+    try {
+      const binPath = path.join(originalCwd, 'bin', 'claudy');
+      return execSync(`node ${binPath} ${cmd}`, {
+        encoding: 'utf-8',
+        env: { ...process.env, NODE_ENV: 'test' }
+      });
+    } catch (error: any) {
+      return error.stdout || error.stderr || '';
+    }
+  };
+
+  it('should display English messages in save command with -a flag', () => {
+    const output = runCommand(`save ${setName} -a -f`);
+
+    // Check that output contains English messages
+    expect(output).toContain('Searching for Claude configuration files...');
+    expect(output).toContain('file(s)');
+    expect(output).toContain('Saving files...');
+    expect(output).toContain(`Set name: "${setName}"`);
+    expect(output).toContain('Save path:');
+
+    // Check that output does NOT contain translation keys
+    expect(output).not.toMatch(/fileSelection\.searchingFiles/);
+    expect(output).not.toMatch(/save\.messages\./);
+    expect(output).not.toMatch(/common:/);
+    expect(output).not.toMatch(/commands:/);
+    expect(output).not.toMatch(/errors:/);
+  });
+
+  it('should display English messages when no files are found', async () => {
+    // Remove test files
+    await fs.remove('CLAUDE.md');
+    await fs.remove('.claude');
+
+    const output = runCommand(`save ${setName} -a`);
+
+    // Check for English error message
+    expect(output).toContain('No files to save were found');
+
+    // Check that output does NOT contain translation keys
+    expect(output).not.toMatch(/resource\.noFilesFound/);
+    expect(output).not.toMatch(/errors:/);
+    
+    // Also check that searching message is in English
+    expect(output).toContain('Searching for Claude configuration files...');
+  });
+
+  it('should display English messages in list command', () => {
+    // First save a set
+    runCommand(`save ${setName} -a -f`);
+
+    const output = runCommand('list');
+
+    // Check that output contains English messages
+    expect(output).toContain('Set Name');
+    expect(output).toContain(setName);
+
+    // Check that output does NOT contain translation keys
+    expect(output).not.toMatch(/list\.messages\./);
+    expect(output).not.toMatch(/commands:/);
+  });
+
+  it('should display English messages in delete command', () => {
+    // First save a set
+    runCommand(`save ${setName} -a -f`);
+
+    const output = runCommand(`delete ${setName} -f`);
+
+    // Check that output contains English messages
+    expect(output).toContain(`Deleting set '${setName}'...`);
+    expect(output).toContain(`Successfully deleted set '${setName}'`);
+
+    // Check that output does NOT contain translation keys
+    expect(output).not.toMatch(/delete\.messages\./);
+    expect(output).not.toMatch(/commands:/);
+  });
+
+  it('should display English error messages for invalid set names', () => {
+    const output = runCommand('save "../invalid" -a');
+
+    // Check for English validation message
+    expect(output).toContain('Invalid set name');
+
+    // Check that output does NOT contain translation keys
+    expect(output).not.toMatch(/validation\.invalidName/);
+    expect(output).not.toMatch(/path\./);
+    expect(output).not.toMatch(/common:/);
+  });
+});

--- a/tests/integration/cli-output.test.ts
+++ b/tests/integration/cli-output.test.ts
@@ -45,7 +45,8 @@ describe('CLI output does not contain translation keys', () => {
         env: { ...process.env, NODE_ENV: 'test' }
       });
     } catch (error: any) {
-      return error.stdout || error.stderr || '';
+      // Combine both stdout and stderr for error cases
+      return (error.stdout || '') + (error.stderr || '');
     }
   };
 

--- a/tests/integration/i18n-messages.test.ts
+++ b/tests/integration/i18n-messages.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { initI18n, t } from '../../src/utils/i18n.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('i18n message translation', () => {
+  beforeAll(async () => {
+    await initI18n();
+  });
+
+  describe('all translation keys resolve to actual messages', () => {
+    it('should translate fileSelection messages correctly', () => {
+      expect(t('common:fileSelection.searchingFiles')).toBe('Searching for Claude configuration files...');
+      expect(t('common:fileSelection.howToSelect')).toBe('Select file selection method:');
+      expect(t('common:fileSelection.bothFiles')).toBe('Both files (Project level + User level)');
+      expect(t('common:fileSelection.projectOnly')).toBe('Project level files only');
+      expect(t('common:fileSelection.userOnly')).toBe('User level files only');
+      expect(t('common:fileSelection.customSelect')).toBe('Custom selection (select files individually)');
+      expect(t('common:fileSelection.selectAllProject')).toBe('Select all project level files');
+      expect(t('common:fileSelection.selectAllUser')).toBe('Select all user level files');
+      expect(t('common:fileSelection.projectLevelSeparator')).toBe('--- Project level ---');
+      expect(t('common:fileSelection.errorSelecting')).toBe('Error occurred while selecting files');
+      expect(t('common:fileSelection.filesSelected', { count: 5 })).toBe('✓ 5 file(s) selected');
+    });
+
+    it('should translate path validation messages correctly', () => {
+      expect(t('common:path.homeNotFound')).toBe('Home directory not found');
+      expect(t('common:path.setNameRequired')).toBe('Set name is required');
+      expect(t('common:path.invalidSetName')).toBe('Invalid set name');
+      expect(t('common:path.emptyPartInName')).toBe('Set name contains empty parts');
+      expect(t('common:path.invalidCharacters')).toBe('Set name contains invalid characters');
+      expect(t('common:path.reservedWord', { part: 'test' })).toBe('"test" is a reserved word and cannot be used');
+      expect(t('common:path.cannotStartWithDot')).toBe('Set name cannot start with a dot');
+    });
+
+    it('should translate error messages correctly', () => {
+      expect(t('errors:operation.retryAfterError', { waitTime: 1000, attempt: 1, maxAttempts: 3 }))
+        .toBe('An error occurred. Retrying in 1000ms... (1/3)');
+      expect(t('errors:permission.fileAccessDenied', { path: ': /test/path' }))
+        .toBe('Access denied to file or directory: /test/path');
+      expect(t('errors:filesystem.diskFullWithPath', { path: ': /test/path' }))
+        .toBe('Insufficient disk space: /test/path');
+      expect(t('errors:resource.setNotFoundDetail', { setName: 'test-set' }))
+        .toBe('Set "test-set" not found. Use \'claudy list\' to check available sets.');
+    });
+
+    it('should translate solution headers correctly', () => {
+      expect(t('errors:solutionHeader')).toBe('Solutions');
+      const permissionSolutions = t('errors:solutions.permissionDenied', { returnObjects: true }) as string[];
+      expect(Array.isArray(permissionSolutions)).toBe(true);
+      expect(permissionSolutions).toContain('Check the permissions of the file or directory');
+      
+      const diskSolutions = t('errors:solutions.diskFull', { returnObjects: true }) as string[];
+      expect(Array.isArray(diskSolutions)).toBe(true);
+      expect(diskSolutions).toContain('Check available disk space');
+    });
+
+    it('should translate config messages correctly', () => {
+      expect(t('common:config.initialized')).toBe('claudy configuration initialized (XDG Base Directory compliant)');
+    });
+
+    it('should translate debug messages correctly', () => {
+      expect(t('common:debug.directorySecured', { dirPath: '/test/path' })).toBe('Directory created: /test/path');
+      expect(t('common:debug.fileRead', { filePath: '/test/file.txt' })).toBe('File read: /test/file.txt');
+      expect(t('common:debug.fileWritten', { filePath: '/test/file.txt' })).toBe('File written: /test/file.txt');
+      expect(t('common:debug.fileCopied', { src: '/src/file', dest: '/dest/file' })).toBe('File copied: /src/file → /dest/file');
+      expect(t('common:debug.fileDeleted', { filePath: '/test/file.txt' })).toBe('File deleted: /test/file.txt');
+      expect(t('common:debug.directoryCopied', { src: '/src/dir', dest: '/dest/dir' })).toBe('Directory copied: /src/dir → /dest/dir');
+    });
+  });
+
+  describe('no hardcoded messages in logger calls', () => {
+    it('should not output translation keys directly', () => {
+      // Mock logger methods to capture output
+      const loggerSpy = {
+        info: vi.spyOn(logger, 'info'),
+        error: vi.spyOn(logger, 'error'),
+        warn: vi.spyOn(logger, 'warn'),
+        success: vi.spyOn(logger, 'success'),
+        debug: vi.spyOn(logger, 'debug')
+      };
+
+      // Test common translation patterns
+      logger.info(t('common:fileSelection.searchingFiles'));
+      logger.error(t('errors:operation.saveError'));
+      logger.warn(t('errors:operation.retryAfterError', { waitTime: 1000, attempt: 1, maxAttempts: 3 }));
+      logger.success(t('common:config.initialized'));
+      logger.debug(t('common:debug.fileRead', { filePath: '/test' }));
+
+      // Verify that no call contains just the translation key
+      expect(loggerSpy.info).toHaveBeenCalledWith('Searching for Claude configuration files...');
+      expect(loggerSpy.error).toHaveBeenCalledWith('Failed to save the set.');
+      expect(loggerSpy.warn).toHaveBeenCalledWith('An error occurred. Retrying in 1000ms... (1/3)');
+      expect(loggerSpy.success).toHaveBeenCalledWith('claudy configuration initialized (XDG Base Directory compliant)');
+      expect(loggerSpy.debug).toHaveBeenCalledWith('File read: /test');
+
+      // Verify no call contains namespace prefix
+      for (const spy of Object.values(loggerSpy)) {
+        spy.mock.calls.forEach(call => {
+          expect(call[0]).not.toMatch(/^(common|commands|errors):/);
+        });
+      }
+
+      // Restore spies
+      Object.values(loggerSpy).forEach(spy => spy.mockRestore());
+    });
+  });
+});

--- a/tests/utils/file-selector.test.ts
+++ b/tests/utils/file-selector.test.ts
@@ -189,12 +189,12 @@ describe('file-selector', () => {
       expect(mockInquirer.prompt).toHaveBeenCalledWith({
         type: 'list',
         name: 'selection',
-        message: 'ファイルの選択方法を選んでください:',
+        message: 'Select file selection method:',
         choices: expect.arrayContaining([
-          expect.objectContaining({ name: '両方のファイル（プロジェクトレベル + ユーザーレベル）', value: 'both' }),
-          expect.objectContaining({ name: 'プロジェクトレベルのファイルのみ', value: 'project' }),
-          expect.objectContaining({ name: 'ユーザーレベルのファイルのみ', value: 'user' }),
-          expect.objectContaining({ name: 'カスタム選択（個別にファイルを選択）', value: 'custom' })
+          expect.objectContaining({ name: 'Both files (Project level + User level)', value: 'both' }),
+          expect.objectContaining({ name: 'Project level files only', value: 'project' }),
+          expect.objectContaining({ name: 'User level files only', value: 'user' }),
+          expect.objectContaining({ name: 'Custom selection (select files individually)', value: 'custom' })
         ]),
         default: 'both'
       });

--- a/tests/utils/path.test.ts
+++ b/tests/utils/path.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
 import * as path from '../../src/utils/path';
 import os from 'os';
 import nodePath from 'path';
+import { initI18n } from '../../src/utils/i18n.js';
 
 describe('path utils', () => {
   const originalEnv = process.env;
+
+  beforeAll(async () => {
+    await initI18n();
+  });
 
   beforeEach(() => {
     process.env = { ...originalEnv };
@@ -145,12 +150,12 @@ describe('path utils', () => {
     });
 
     it('should throw error for empty set name', () => {
-      expect(() => path.getSetDir('')).toThrow('セット名を指定してください');
+      expect(() => path.getSetDir('')).toThrow('Set name is required');
     });
 
     it('should throw error for path traversal attempts', () => {
-      expect(() => path.getSetDir('../etc')).toThrow('無効なセット名です');
-      expect(() => path.getSetDir('test/../../../etc')).toThrow('無効なセット名です');
+      expect(() => path.getSetDir('../etc')).toThrow('Invalid set name');
+      expect(() => path.getSetDir('test/../../../etc')).toThrow('Invalid set name');
     });
   });
 
@@ -164,41 +169,41 @@ describe('path utils', () => {
     });
 
     it('should reject empty set names', () => {
-      expect(() => path.validateSetName('')).toThrow('セット名を指定してください');
-      expect(() => path.validateSetName('  ')).toThrow('セット名を指定してください');
+      expect(() => path.validateSetName('')).toThrow('Set name is required');
+      expect(() => path.validateSetName('  ')).toThrow('Set name is required');
     });
 
     it('should reject set names with path traversal', () => {
-      expect(() => path.validateSetName('../etc')).toThrow('無効なセット名です');
-      expect(() => path.validateSetName('test/../../../etc')).toThrow('無効なセット名です');
-      expect(() => path.validateSetName('/absolute/path')).toThrow('無効なセット名です');
+      expect(() => path.validateSetName('../etc')).toThrow('Invalid set name');
+      expect(() => path.validateSetName('test/../../../etc')).toThrow('Invalid set name');
+      expect(() => path.validateSetName('/absolute/path')).toThrow('Invalid set name');
     });
 
     it('should reject set names with invalid characters', () => {
-      expect(() => path.validateSetName('test:name')).toThrow('セット名に使用できない文字が含まれています');
-      expect(() => path.validateSetName('test*name')).toThrow('セット名に使用できない文字が含まれています');
-      expect(() => path.validateSetName('test?name')).toThrow('セット名に使用できない文字が含まれています');
-      expect(() => path.validateSetName('test<name')).toThrow('セット名に使用できない文字が含まれています');
-      expect(() => path.validateSetName('test>name')).toThrow('セット名に使用できない文字が含まれています');
-      expect(() => path.validateSetName('test|name')).toThrow('セット名に使用できない文字が含まれています');
-      expect(() => path.validateSetName('test"name')).toThrow('セット名に使用できない文字が含まれています');
+      expect(() => path.validateSetName('test:name')).toThrow('Set name contains invalid characters');
+      expect(() => path.validateSetName('test*name')).toThrow('Set name contains invalid characters');
+      expect(() => path.validateSetName('test?name')).toThrow('Set name contains invalid characters');
+      expect(() => path.validateSetName('test<name')).toThrow('Set name contains invalid characters');
+      expect(() => path.validateSetName('test>name')).toThrow('Set name contains invalid characters');
+      expect(() => path.validateSetName('test|name')).toThrow('Set name contains invalid characters');
+      expect(() => path.validateSetName('test"name')).toThrow('Set name contains invalid characters');
     });
 
     it('should reject reserved names', () => {
-      expect(() => path.validateSetName('CON')).toThrow('"CON"は予約語のため使用できません');
-      expect(() => path.validateSetName('PRN')).toThrow('"PRN"は予約語のため使用できません');
-      expect(() => path.validateSetName('profiles')).toThrow('"profiles"は予約語のため使用できません');
+      expect(() => path.validateSetName('CON')).toThrow('"CON" is a reserved word and cannot be used');
+      expect(() => path.validateSetName('PRN')).toThrow('"PRN" is a reserved word and cannot be used');
+      expect(() => path.validateSetName('profiles')).toThrow('"profiles" is a reserved word and cannot be used');
     });
 
     it('should reject set names starting with dot', () => {
-      expect(() => path.validateSetName('.hidden')).toThrow('セット名はドットで始めることはできません');
-      expect(() => path.validateSetName('test/.hidden')).toThrow('セット名はドットで始めることはできません');
+      expect(() => path.validateSetName('.hidden')).toThrow('Set name cannot start with a dot');
+      expect(() => path.validateSetName('test/.hidden')).toThrow('Set name cannot start with a dot');
     });
 
     it('should reject set names with empty parts', () => {
-      expect(() => path.validateSetName('test//name')).toThrow('セット名に空のパートが含まれています');
-      expect(() => path.validateSetName('test/')).toThrow('セット名に空のパートが含まれています');
-      expect(() => path.validateSetName('/test')).toThrow('無効なセット名です'); // Absolute path
+      expect(() => path.validateSetName('test//name')).toThrow('Set name contains empty parts');
+      expect(() => path.validateSetName('test/')).toThrow('Set name contains empty parts');
+      expect(() => path.validateSetName('/test')).toThrow('Invalid set name'); // Absolute path
     });
   });
 });


### PR DESCRIPTION
## 概要
i18n翻訳キーが実際のメッセージの代わりに表示される問題を修正しました。

## 関連するIssue
fixes #45

## 変更内容
- ハードコーディングされた日本語メッセージを英語化し、i18n対応
  - `src/utils/file-selector.ts`: ファイル選択のUIメッセージ
  - `src/utils/errorHandler.ts`: エラーメッセージと解決策
  - `src/utils/config.ts`: 設定初期化メッセージ
  - `src/utils/path.ts`: パス検証エラーメッセージ
  - `src/utils/file.ts`: デバッグメッセージ
  - `src/commands/list.ts`: デバッグメッセージ
  - `src/utils/reference-parser.ts`: デバッグメッセージ
  - `src/commands/save.ts`: エラーメッセージ

- 翻訳キーの追加
  - `locales/en/common.json`: fileSelection、path、debug、configセクションに新しいキーを追加
  - `locales/en/errors.json`: 新しいエラーメッセージキーを追加

- テストの追加と修正
  - `tests/integration/i18n-messages.test.ts`: 翻訳キーが正しく解決されることを確認するテスト
  - `tests/integration/cli-output.test.ts`: CLI出力に翻訳キーが表示されないことを確認するテスト
  - `tests/utils/path.test.ts`: エラーメッセージを英語に更新、i18n初期化を追加
  - `tests/utils/file-selector.test.ts`: UIテキストを英語に更新

## テスト結果
- [x] ユニットテスト実行済み (npm run test)
- [x] ESLint実行済み (npm run lint)
- [x] TypeScriptビルド成功 (npm run build)

## レビューポイント
1. すべてのハードコーディングされたメッセージが適切にi18n化されているか
2. 翻訳キーの命名規則が一貫しているか
3. エラーメッセージが適切に英語化されているか
4. デバッグメッセージのi18n化が必要かどうか（現在はi18n化済み）

🤖 Generated with [Claude Code](https://claude.ai/code)