### PR TITLE
fix: npmパッケージでi18n翻訳が適用されない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "locales"
   ],
   "repository": {
     "type": "git",

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -2,15 +2,53 @@ import i18next from 'i18next';
 import Backend from 'i18next-fs-backend';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs-extra';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 let isInitialized = false;
 
+/**
+ * パッケージのルートディレクトリを見つける
+ * 開発環境とnpmパッケージの両方で動作するように設計
+ */
+function findPackageRoot(): string {
+  // dist/utils/i18n.js から開始
+  let currentDir = __dirname;
+  
+  // 最大5階層まで遡って package.json を探す
+  for (let i = 0; i < 5; i++) {
+    const packageJsonPath = path.join(currentDir, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      return currentDir;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+  
+  // フォールバック: __dirname から2階層上
+  return path.join(__dirname, '../..');
+}
+
 export async function initI18n(): Promise<void> {
   if (isInitialized) {
     return;
+  }
+
+  const packageRoot = findPackageRoot();
+  const localesPath = path.join(packageRoot, 'locales', '{{lng}}', '{{ns}}.json');
+
+  // デバッグ情報: 環境変数 CLAUDY_DEBUG=true で有効化
+  if (process.env.CLAUDY_DEBUG === 'true') {
+    console.log('i18n Debug Info:');
+    console.log('  __dirname:', __dirname);
+    console.log('  Package root:', packageRoot);
+    console.log('  Locales path pattern:', localesPath);
+    
+    // 実際のファイルパスを確認
+    const testPath = localesPath.replace('{{lng}}', 'en').replace('{{ns}}', 'common');
+    console.log('  Test file path:', testPath);
+    console.log('  Test file exists:', fs.existsSync(testPath));
   }
 
   await i18next
@@ -18,12 +56,12 @@ export async function initI18n(): Promise<void> {
     .init({
       lng: 'en',
       fallbackLng: 'en',
-      debug: false,
+      debug: process.env.CLAUDY_DEBUG === 'true',
       interpolation: {
         escapeValue: false,
       },
       backend: {
-        loadPath: path.join(__dirname, '../../locales/{{lng}}/{{ns}}.json'),
+        loadPath: localesPath,
       },
       ns: ['common', 'commands', 'errors'],
       defaultNS: 'common',


### PR DESCRIPTION
## 概要
npmパッケージとしてインストールした際にi18n翻訳が適用されない問題を修正しました。

## 問題の詳細
- `npm install -g claudy`でインストールしたバージョンでは、コマンドヘルプやメッセージが翻訳キー（例: `app.description`）のまま表示される
- ローカルビルドでは正常に翻訳が適用される

## 原因
1. npmパッケージに`locales`ディレクトリが含まれていなかった（package.jsonの`files`フィールドに未指定）
2. 翻訳ファイルのパス解決が固定的で、異なる環境で適切に動作しなかった

## 変更内容
- package.jsonの`files`フィールドに`locales`ディレクトリを追加
- 動的なパッケージルート検出機能を実装（`findPackageRoot()`関数）
- デバッグモード（`CLAUDY_DEBUG=true`）を追加し、翻訳ファイルのパス解決をデバッグ可能に

## テスト方法
1. このブランチでビルド: `npm run build`
2. パッケージをローカルインストール: `npm pack && npm install -g claudy-*.tgz`
3. コマンドを実行して翻訳が適用されることを確認: `claudy --help`
4. デバッグモードで確認: `CLAUDY_DEBUG=true claudy --help`

🤖 Generated with [Claude Code](https://claude.ai/code)