### PR TITLE
fix: loadコマンドで保存済みの参照ファイルが復元されない問題を修正

### DIFF
--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -159,27 +159,21 @@ interface FileWithScope {
  * @throws {ClaudyError} ファイル検索中にエラーが発生した場合
  */
 async function getSetFiles(setDir: string): Promise<FileWithScope[]> {
-  const patterns = [
-    'CLAUDE.md',
-    '.claude/**/*.md'
-  ];
-
   const filesWithScope: FileWithScope[] = [];
   
   // プロジェクトレベルのファイルを検索
   const projectDir = path.join(setDir, 'project');
   try {
     await stat(projectDir);
-    for (const pattern of patterns) {
-      const matches = await glob(pattern, {
-        cwd: projectDir,
-        nodir: true,
-        dot: true
-      });
-      matches.forEach(file => {
-        filesWithScope.push({ file, scope: 'project', baseDir: projectDir });
-      });
-    }
+    // すべてのファイルを再帰的に取得
+    const matches = await glob('**/*', {
+      cwd: projectDir,
+      nodir: true,
+      dot: true
+    });
+    matches.forEach(file => {
+      filesWithScope.push({ file, scope: 'project', baseDir: projectDir });
+    });
   } catch {
     // project ディレクトリが存在しない場合は無視
   }
@@ -188,16 +182,15 @@ async function getSetFiles(setDir: string): Promise<FileWithScope[]> {
   const userDir = path.join(setDir, 'user');
   try {
     await stat(userDir);
-    for (const pattern of patterns) {
-      const matches = await glob(pattern, {
-        cwd: userDir,
-        nodir: true,
-        dot: true
-      });
-      matches.forEach(file => {
-        filesWithScope.push({ file, scope: 'user', baseDir: userDir });
-      });
-    }
+    // すべてのファイルを再帰的に取得
+    const matches = await glob('**/*', {
+      cwd: userDir,
+      nodir: true,
+      dot: true
+    });
+    matches.forEach(file => {
+      filesWithScope.push({ file, scope: 'user', baseDir: userDir });
+    });
   } catch {
     // user ディレクトリが存在しない場合は無視
   }


### PR DESCRIPTION
## 概要
loadコマンドで保存済みの参照ファイルが復元されない問題を修正しました。

## 関連するIssue
fixes #50

## 変更内容
- `src/commands/load.ts` の `getSetFiles` 関数を修正
  - 固定パターン（`CLAUDE.md`と`.claude/**/*.md`）から `**/*` パターンに変更
  - セットディレクトリ内のすべてのファイルを再帰的に取得するように改善
- `tests/commands/load.test.ts` のテストを更新
  - 既存のテストのモックを新しいパターンに対応
  - 参照ファイルの復元を確認する新しいテストケースを追加

## 問題の詳細
### 修正前の動作
- saveコマンドでは`@`記法で参照されているファイルも正しく保存される
- しかし、loadコマンドでは固定パターンのファイルのみが復元対象となり、参照ファイルが復元されない

### 修正後の動作
- loadコマンドでセットディレクトリ内のすべてのファイルが復元される
- 参照ファイルも元の相対パス構造を保持して復元される

## テスト結果
- [x] ユニットテスト実行済み（全139テストが通過）
- [x] 参照ファイルの復元を確認する新しいテストケースを追加
- [x] 既存の機能に影響がないことを確認

## 動作確認
saveコマンドで保存したすべてのファイル（CLAUDE.md、.claude/配下のファイル、および参照ファイル）がloadコマンドで正しく復元されることを確認しました。

## レビューポイント
- `getSetFiles`関数の変更が適切かどうか
- パフォーマンスへの影響（すべてのファイルを取得するため）
- エラーハンドリングの妥当性