### PR TITLE
fix: saveコマンド実行時に保存先ディレクトリをクリーンアップする機能

### DIFF
--- a/locales/en/commands.json
+++ b/locales/en/commands.json
@@ -37,7 +37,9 @@
       "loadCommand": "  $ claudy load {{name}}",
       "fileListItem": "  - {{prefix}}{{file}}",
       "projectLevel": "  - Project level: {{count}} file(s)",
-      "userLevel": "  - User level: {{count}} file(s)"
+      "userLevel": "  - User level: {{count}} file(s)",
+      "cleaningUpDir": "Cleaning up existing directory: {{path}}",
+      "cleanupComplete": "Directory cleanup completed: {{path}}"
     }
   },
   "load": {

--- a/tests/integration/save.integration.test.ts
+++ b/tests/integration/save.integration.test.ts
@@ -114,7 +114,7 @@ describe('saveコマンド統合テスト', () => {
       await executeSaveCommand('test-set', { all: true, force: true });
 
       // 新しいファイルで上書きされたか確認
-      expect(await fs.pathExists(path.join(setDir, 'old.md'))).toBe(true); // 既存ファイルも保持される（copyのoverwriteオプション）
+      expect(await fs.pathExists(path.join(setDir, 'old.md'))).toBe(false); // 既存ファイルは削除される（ディレクトリクリーンアップ）
       expect(await fs.pathExists(path.join(setDir, 'CLAUDE.md'))).toBe(true);
       expect(await fs.readFile(path.join(setDir, 'CLAUDE.md'), 'utf-8')).toBe('# New CLAUDE.md\n');
     });


### PR DESCRIPTION
## 概要
saveコマンド実行時に、既存の保存先ディレクトリを完全にクリーンアップしてから新しいファイルを保存する機能を実装しました。

## 関連するIssue
fixes #52

## 変更内容
- `src/commands/save.ts`: 既存セットのディレクトリを削除する処理を追加
- `locales/en/commands.json`: クリーンアップ関連のメッセージを追加
- `tests/commands/save.test.ts`: ディレクトリクリーンアップ機能の単体テストを追加
- `tests/integration/save.integration.test.ts`: 統合テストを修正（古いファイルが削除されることを確認）

## テスト結果
- [x] ユニットテスト実行済み
- [x] システムテスト実行済み
- [x] npm run lint実行済み

## レビューポイント
- ディレクトリ削除にfs-extraの`remove()`メソッドを使用していますが、これが最適な方法か
- エラーハンドリングが適切に実装されているか
- 国際化対応（現在は英語のみ）の実装方針