### PR TITLE
fix: npmパッケージ初回公開時のCI設定を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,16 @@ jobs:
         CURRENT_VERSION=$(node -p "require('./package.json').version")
         echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
         
-        # Check if this version is already published
-        if npm view claudy@$CURRENT_VERSION version >/dev/null 2>&1; then
-          echo "version_changed=false" >> $GITHUB_OUTPUT
+        # Check if package exists and if this version is already published
+        if npm view claudy version >/dev/null 2>&1; then
+          # Package exists, check if this version is published
+          if npm view claudy@$CURRENT_VERSION version >/dev/null 2>&1; then
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+          fi
         else
+          # Package doesn't exist yet, so we should publish
           echo "version_changed=true" >> $GITHUB_OUTPUT
         fi
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Publish to npm
       run: npm publish
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     
     - name: Create GitHub Release
       uses: actions/create-release@v1


### PR DESCRIPTION
## 概要
npmパッケージの初回公開時に発生するCIエラーを修正しました。

## 問題
現在のCIでは、存在しないバージョンを公開しようとした際に以下のエラーが発生していました：
```
npm error 404 Not Found - PUT https://registry.npmjs.org/claudy - Not found
npm error 404  'claudy@0.2.4' is not in this registry.
```

## 修正内容
1. **release.yml**: `NODE_AUTH_TOKEN`を`GITHUB_TOKEN`から`NPM_TOKEN`に変更
   - npmへの公開には適切な認証トークンが必要です

2. **ci.yml**: パッケージが存在しない場合の処理を追加
   - パッケージ自体が存在するかをまず確認
   - 存在しない場合は初回公開として処理
   - 存在する場合は、該当バージョンが公開済みかを確認

## テスト
- [x] CI設定の構文チェック
- [ ] 実際のCI/CDパイプラインでの動作確認（マージ後）

🤖 Generated with [Claude Code](https://claude.ai/code)